### PR TITLE
chore: bump version to 1.11.7 in package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "blaze-install",
-  "version": "1.11.5",
+  "version": "1.11.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "blaze-install",
-      "version": "1.11.5",
+      "version": "1.11.7",
       "hasInstallScript": true,
       "license": "ISC",
       "workspaces": [


### PR DESCRIPTION
# chore: bump version to 1.11.7 in package-lock.json

## 📋 Description

This PR updates the `package-lock.json` file to reflect the version bump to 1.11.7 that was made in `package.json`.

## 🔄 Changes

- Updated `package-lock.json` to version 1.11.7
- Ensures lockfile is in sync with package.json version

## ✅ Checklist

- ✅Version bump in package-lock.json matches package.json
- ✅ Lockfile is up to date with current dependencies

---

**Ready for review and merge! 🎉**