### PR TITLE
fix: fall back to 'master' for GitHub repos whose default branch isn't 'main' (#11)

### DIFF
--- a/lib/installTree.js
+++ b/lib/installTree.js
@@ -208,11 +208,16 @@ async function downloadWithRetry(url, dest, headers = {}, maxRetries = 3) {
 
 const { downloadWithSSH, getGitHubAuthHeaders } = require('./sshHelper');
 
-async function validateGithubOrTarballSpec(spec) {
+async function validateGithubOrTarballSpec(spec, gh) {
+  // Cheap early-out for tarball URLs.
   if (isTarballUrl(spec)) return true;
-  const gh = await parseGithubSpec(spec);
-  if (gh) return true;
-  return false;
+  // If the caller already parsed the spec (e.g. worker has `tarballMeta`
+  // from the resolution phase), trust that result and skip the second
+  // parseGithubSpec call — it would otherwise hit the GitHub API again
+  // and increase install latency / rate-limit risk. Single-arg callers
+  // still get the old behaviour via the fallback below.
+  if (!gh) gh = await parseGithubSpec(spec);
+  return !!gh;
 }
 
 function sanitizePackageDirName(name) {
@@ -287,12 +292,24 @@ async function installTree(tree, destDir, options = {}) {
       bar.update(i, { pkg: chalk.yellow(name) });
       return;
     }
-    // Only handle GitHub/tarball install if info.version is a GitHub/tarball spec
-    const gh = await parseGithubSpec(info.version);
-    const isGithubOrTarball = isTarballUrl(info.version) || (gh !== null);
-    if (isGithubOrTarball && (isTarballUrl(tarballMeta.tarballUrl) || tarballMeta.tarballUrl.includes('codeload.github.com'))) {
-      // Validate spec
-      if (!(await validateGithubOrTarballSpec(info.version))) {
+    // Only handle GitHub/tarball install if info.version is a GitHub/tarball spec.
+    // Both `gh` and `isGithubOrTarball` are derived cheaply from `tarballMeta`
+    // (which the resolution phase already populated), so we avoid a redundant
+    // parseGithubSpec(info.version) call here — that would otherwise trigger
+    // a second GitHub API request per GitHub spec and burn rate-limit budget.
+    const gh = (tarballMeta && tarballMeta.user && tarballMeta.name)
+      ? tarballMeta
+      : null;
+    const isGithubOrTarball = !!tarballMeta.tarballUrl && (
+      isTarballUrl(tarballMeta.tarballUrl) ||
+      tarballMeta.tarballUrl.includes('codeload.github.com')
+    );
+    if (isGithubOrTarball) {
+      // Tertiary safety: validate cheaply using the already-parsed `gh`
+      // (no extra GitHub API call). The outer condition already established
+      // the spec is valid via `tarballMeta`, but this preserves the original
+      // error message for any unforeseen edge cases.
+      if (!(await validateGithubOrTarballSpec(info.version, gh))) {
         console.error(chalk.red(`Invalid GitHub/tarball spec: '${info.version}'.\nExamples: user/repo, user/repo#branch, github:user/repo#sha, https://example.com/pkg.tgz`));
         throw new Error(`Invalid GitHub/tarball spec: ${info.version}`);
       }
@@ -470,11 +487,14 @@ async function installTree(tree, destDir, options = {}) {
           }
         }
       }
-      // Extract
+      // Extract. Drop the on-disk tarball on extract failure so the next
+      // run doesn't treat a corrupted/half-extracted package as a cache hit
+      // and silently ship a broken node_modules entry.
       const tar = require("tar");
       try {
         await tar.x({ file: tarballPath, C: dest, strip: 1 });
       } catch (err) {
+        await fs.unlink(tarballPath).catch(() => {});
         console.error(chalk.red(`Failed to extract tarball: ${tarballPath}\n${err.message}`));
         throw err;
       }

--- a/lib/installTree.js
+++ b/lib/installTree.js
@@ -1,4 +1,3 @@
-"use strict";
 const axios = require("axios");
 const fs = require("fs/promises");
 const path = require("path");
@@ -8,399 +7,573 @@ const cliProgress = require("cli-progress");
 const { spawn } = require("child_process");
 const chalk = require('chalk');
 let boxen = require('boxen');
-if (boxen && boxen.default)
-    boxen = boxen.default;
+if (boxen && boxen.default) boxen = boxen.default;
+
 async function runLifecycleScript(pkgDir, scriptName, pkgName) {
-    const pkgJsonPath = path.join(pkgDir, "package.json");
-    try {
-        const data = await fs.readFile(pkgJsonPath, "utf-8");
-        const pkg = JSON.parse(data);
-        if (pkg.scripts && pkg.scripts[scriptName]) {
-            console.log(chalk.cyan(`[${pkgName}] Running ${scriptName} script...`));
-            await new Promise((resolve) => {
-                const child = spawn(process.platform === "win32" ? "cmd" : "sh", [process.platform === "win32" ? "/c" : "-c", pkg.scripts[scriptName]], {
-                    cwd: pkgDir,
-                    stdio: "inherit",
-                });
-                child.on("close", async (code) => {
-                    if (code !== 0) {
-                        console.warn(chalk.yellow(`[${pkgName}] ${scriptName} script failed with code ${code}`));
-                    }
-                    resolve();
-                });
-            });
-        }
+  const pkgJsonPath = path.join(pkgDir, "package.json");
+  try {
+    const data = await fs.readFile(pkgJsonPath, "utf-8");
+    const pkg = JSON.parse(data);
+    if (pkg.scripts && pkg.scripts[scriptName]) {
+      console.log(
+        chalk.cyan(`[${pkgName}] Running ${scriptName} script...`),
+      );
+      await new Promise((resolve) => {
+        const child = spawn(
+          process.platform === "win32" ? "cmd" : "sh",
+          [process.platform === "win32" ? "/c" : "-c", pkg.scripts[scriptName]],
+          {
+            cwd: pkgDir,
+            stdio: "inherit",
+          },
+        );
+        child.on("close", async (code) => {
+          if (code !== 0) {
+            console.warn(
+              chalk.yellow(
+                `[${pkgName}] ${scriptName} script failed with code ${code}`,
+              ),
+            );
+          }
+          resolve();
+        });
+      });
     }
-    catch (err) {
-        // Ignore errors reading package.json or missing scripts
-    }
+  } catch (err) {
+    // Ignore errors reading package.json or missing scripts
+  }
 }
+
 const METADATA_CACHE_DIR = path.join(os.homedir(), ".blaze_metadata_cache");
 const TARBALL_CACHE_DIR = path.join(os.homedir(), ".blaze_cache", "tarballs");
+
 async function getTarballUrl(name, version) {
-    await fs.mkdir(METADATA_CACHE_DIR, { recursive: true });
-    const cacheFile = path.join(METADATA_CACHE_DIR, `${name.replace("/", "_")}-${version}.json`);
-    let metadata;
+  await fs.mkdir(METADATA_CACHE_DIR, { recursive: true });
+  const cacheFile = path.join(
+    METADATA_CACHE_DIR,
+    `${name.replace("/", "_")}-${version}.json`,
+  );
+  let metadata;
+  try {
+    const cachedData = await fs.readFile(cacheFile, "utf-8");
+    metadata = JSON.parse(cachedData);
+  } catch (err) {
+    if (err.code !== "ENOENT") {
+      console.warn(
+        chalk.yellow(
+          `Could not read metadata cache for ${name}@${version}: ${err.message}`,
+        ),
+      );
+    }
+    const url = `https://registry.npmjs.org/${encodeURIComponent(name)}/${version}`;
+    const { data } = await axios.get(url);
+    metadata = data;
     try {
-        const cachedData = await fs.readFile(cacheFile, "utf-8");
-        metadata = JSON.parse(cachedData);
+      await fs.writeFile(cacheFile, JSON.stringify(data), "utf-8");
+    } catch (err) {
+      console.warn(
+        chalk.yellow(
+          `Could not write to metadata cache for ${name}@${version}: ${err.message}`,
+        ),
+      );
     }
-    catch (err) {
-        if (err.code !== "ENOENT") {
-            console.warn(chalk.yellow(`Could not read metadata cache for ${name}@${version}: ${err.message}`));
-        }
-        const url = `https://registry.npmjs.org/${encodeURIComponent(name)}/${version}`;
-        const { data } = await axios.get(url);
-        metadata = data;
-        try {
-            await fs.writeFile(cacheFile, JSON.stringify(data), "utf-8");
-        }
-        catch (err) {
-            console.warn(chalk.yellow(`Could not write to metadata cache for ${name}@${version}: ${err.message}`));
-        }
-    }
-    if (metadata.dist && metadata.dist.tarball) {
-        return {
-            tarballUrl: metadata.dist.tarball,
-            shasum: metadata.dist.shasum,
-            integrity: metadata.dist.integrity,
-            signature: metadata.dist.signature || null,
-        };
-    }
-    return { tarballUrl: null, shasum: null, integrity: null, signature: null };
-}
-async function safeRemove(target) {
-    try {
-        const stat = await fs.lstat(target);
-        if (stat.isDirectory() && !stat.isSymbolicLink()) {
-            // console.log(chalk.gray(`➜ Removing directory at ${target}`));
-            await fs.rm(target, { recursive: true, force: true });
-        }
-        else if (stat.isSymbolicLink()) {
-            // console.log(chalk.gray(`➜ Removing symlink at ${target}`));
-            await fs.unlink(target);
-        }
-        else {
-            // console.log(chalk.gray(`➜ Removing file at ${target}`));
-            await fs.unlink(target);
-        }
-    }
-    catch (err) {
-        if (err.code === "ENOENT") {
-            // No log for non-existent
-        }
-        else {
-            throw err;
-        }
-    }
-}
-async function handleLocalDep(depName, depSpec, nodeModulesDir) {
-    const dest = path.join(nodeModulesDir, depName);
-    let src = depSpec.replace(/^(file:|link:)/, "");
-    src = path.resolve(process.cwd(), src);
-    try {
-        await fs.rm(dest, { recursive: true, force: true });
-    }
-    catch { }
-    if (depSpec.startsWith("file:")) {
-        await fs.cp(src, dest, { recursive: true });
-        console.log(chalk.cyan(`Copied local dependency ${depName} from ${src}`));
-    }
-    else if (depSpec.startsWith("link:")) {
-        try {
-            await fs.symlink(src, dest, "dir");
-            console.log(chalk.cyan(`Symlinked local dependency ${depName} from ${src}`));
-        }
-        catch (err) {
-            if (err.code === "EPERM" || err.code === "EEXIST") {
-                await fs.cp(src, dest, { recursive: true });
-                console.log(chalk.cyan(`Copied local dependency ${depName} from ${src} (symlink not permitted)`));
-            }
-            else {
-                throw err;
-            }
-        }
-    }
-}
-async function parseGithubSpec(spec) {
-    // github:user/repo[#ref] or user/repo[#ref]
-    let m = spec.match(/^github:([^/]+)\/([^#]+)(#(.+))?$/);
-    if (!m)
-        m = spec.match(/^([^/]+)\/([^#]+)(#(.+))?$/);
-    if (!m)
-        return null;
-    const user = m[1], repo = m[2];
-    let ref = m[4];
-    // If no ref specified, get the default branch from GitHub
-    if (!ref) {
-        const { getDefaultBranch } = require('./sshHelper');
-        ref = await getDefaultBranch(user, repo);
-    }
+  }
+  if (metadata.dist && metadata.dist.tarball) {
     return {
-        tarballUrl: `https://codeload.github.com/${user}/${repo}/tar.gz/${ref}`,
-        sshUrl: `git@github.com:${user}/${repo}.git`,
-        name: repo,
-        ref,
-        user,
+      tarballUrl: metadata.dist.tarball,
+      shasum: metadata.dist.shasum,
+      integrity: metadata.dist.integrity,
+      signature: metadata.dist.signature || null,
     };
+  }
+  return { tarballUrl: null, shasum: null, integrity: null, signature: null };
 }
-function isTarballUrl(spec) {
-    return /^https?:\/\/.+\.(tgz|tar\.gz)$/.test(spec);
-}
-async function downloadWithRetry(url, dest, headers = {}, maxRetries = 3) {
-    const axiosOpts = { responseType: "stream", headers };
-    let lastErr;
-    for (let attempt = 1; attempt <= maxRetries; attempt++) {
-        try {
-            const response = await axios.get(url, axiosOpts);
-            const writer = require("fs").createWriteStream(dest);
-            await new Promise((resolve, reject) => {
-                response.data.pipe(writer);
-                writer.on("finish", resolve);
-                writer.on("error", reject);
-            });
-            return true;
-        }
-        catch (err) {
-            lastErr = err;
-            if (attempt < maxRetries) {
-                console.warn(chalk.yellow(`Download failed (attempt ${attempt}): ${err.message}. Retrying...`));
-                await new Promise(r => setTimeout(r, 1000 * attempt));
-            }
-        }
+
+async function safeRemove(target) {
+  try {
+    const stat = await fs.lstat(target);
+    if (stat.isDirectory() && !stat.isSymbolicLink()) {
+      // console.log(chalk.gray(`➜ Removing directory at ${target}`));
+      await fs.rm(target, { recursive: true, force: true });
+    } else if (stat.isSymbolicLink()) {
+      // console.log(chalk.gray(`➜ Removing symlink at ${target}`));
+      await fs.unlink(target);
+    } else {
+      // console.log(chalk.gray(`➜ Removing file at ${target}`));
+      await fs.unlink(target);
     }
-    throw lastErr;
-}
-const { downloadWithSSH, getGitHubAuthHeaders } = require('./sshHelper');
-async function validateGithubOrTarballSpec(spec) {
-    if (isTarballUrl(spec))
-        return true;
-    const gh = await parseGithubSpec(spec);
-    if (gh)
-        return true;
-    return false;
-}
-function sanitizePackageDirName(name) {
-    // Replace /, :, #, @, and any non-alphanumeric with -
-    return name.replace(/[^a-zA-Z0-9._-]/g, "-");
-}
-const isVerbose = process.argv.includes('--verbose');
-async function installTree(tree, destDir, options = {}) {
-    const nodeModulesDir = path.join(destDir, "node_modules");
-    await fs.mkdir(nodeModulesDir, { recursive: true });
-    const pkgs = Object.entries(tree);
-    const bar = new cliProgress.SingleBar({
-        format: '{bar} {percentage}% | {value}/{total} 📦',
-        barCompleteChar: '█',
-        barIncompleteChar: '░',
-        hideCursor: true,
-        linewrap: false,
-        clearOnComplete: false,
-        barsize: 30,
-    }, cliProgress.Presets.shades_classic);
-    bar.start(pkgs.length, 0, { pkg: "" });
-    const concurrency = 8;
-    let i = 0;
-    // Step 1: Resolve all tarball URLs in parallel
-    const pkgsWithTarballs = await Promise.all(pkgs.map(async ([name, info]) => {
-        if (info.version &&
-            (info.version.startsWith("file:") || info.version.startsWith("link:"))) {
-            return {
-                name,
-                info,
-                tarballMeta: {
-                    tarballUrl: null,
-                    shasum: null,
-                    integrity: null,
-                    signature: null,
-                },
-            };
-        }
-        // Handle GitHub and tarball URLs
-        if (isTarballUrl(info.version)) {
-            return { name, info, tarballMeta: { tarballUrl: info.version } };
-        }
-        const gh = await parseGithubSpec(info.version);
-        if (gh) {
-            return { name, info, tarballMeta: gh };
-        }
-        // Check if this is an npm alias
-        let packageNameForTarball = name;
-        if (info._alias && info._realPackage) {
-            packageNameForTarball = info._realPackage;
-        }
-        const tarballMeta = await getTarballUrl(packageNameForTarball, info.version);
-        return { name, info, tarballMeta };
-    }));
-    async function worker({ name, info, tarballMeta }) {
-        bar.update(i, { pkg: chalk.yellow(name) });
-        // Handle file: and link: dependencies
-        if (!tarballMeta.tarballUrl) {
-            await handleLocalDep(name, info.version, nodeModulesDir);
-            i++;
-            bar.update(i, { pkg: chalk.yellow(name) });
-            return;
-        }
-        // Only handle GitHub/tarball install if info.version is a GitHub/tarball spec
-        const gh = await parseGithubSpec(info.version);
-        const isGithubOrTarball = isTarballUrl(info.version) || (gh !== null);
-        if (isGithubOrTarball && (isTarballUrl(tarballMeta.tarballUrl) || tarballMeta.tarballUrl.includes('codeload.github.com'))) {
-            // Validate spec
-            if (!(await validateGithubOrTarballSpec(info.version))) {
-                console.error(chalk.red(`Invalid GitHub/tarball spec: '${info.version}'.\nExamples: user/repo, user/repo#branch, github:user/repo#sha, https://example.com/pkg.tgz`));
-                throw new Error(`Invalid GitHub/tarball spec: ${info.version}`);
-            }
-            const safeName = sanitizePackageDirName(name);
-            const dest = path.join(nodeModulesDir, safeName);
-            await safeRemove(dest);
-            await fs.mkdir(dest, { recursive: true });
-            await fs.mkdir(TARBALL_CACHE_DIR, { recursive: true });
-            // Cache tarball by URL hash
-            const crypto = require("crypto");
-            const urlHash = crypto.createHash("sha1").update(tarballMeta.tarballUrl).digest("hex");
-            const tarballPath = path.join(TARBALL_CACHE_DIR, `${name}-${urlHash}.tar.gz`);
-            let usedCache = false;
-            if (await fs.stat(tarballPath).then(() => true, () => false)) {
-                usedCache = true;
-            }
-            else {
-                // Download with retry and auth if needed
-                let headers = {};
-                let useSSH = false;
-                if (tarballMeta.tarballUrl.includes('codeload.github.com')) {
-                    const auth = await getGitHubAuthHeaders();
-                    if (auth.useSSH) {
-                        useSSH = true;
-                    }
-                    else if (auth.Authorization) {
-                        headers = auth;
-                    }
-                }
-                try {
-                    if (useSSH && tarballMeta.sshUrl) {
-                        // Use SSH to clone and create tarball
-                        await downloadWithSSH(tarballMeta.sshUrl, tarballMeta.ref, tarballPath, isVerbose);
-                    }
-                    else {
-                        await downloadWithRetry(tarballMeta.tarballUrl, tarballPath, headers, 3);
-                    }
-                }
-                catch (err) {
-                    if (tarballMeta.tarballUrl.includes('codeload.github.com')) {
-                        if (!process.env.GITHUB_TOKEN) {
-                            console.error(chalk.red(`Failed to download from GitHub. For private repos, either:`));
-                            console.error(chalk.red(`  1. Set GITHUB_TOKEN env var with a personal access token, or`));
-                            console.error(chalk.red(`  2. Add your SSH key with 'ssh-add' for SSH authentication`));
-                        }
-                    }
-                    if (err.response && (err.response.status === 403 || err.response.status === 404)) {
-                        console.error(chalk.red(`HTTP ${err.response.status} for ${tarballMeta.tarballUrl}. Check repo access or token.`));
-                    }
-                    throw err;
-                }
-            }
-            // Extract
-            const tar = require("tar");
-            try {
-                await tar.x({ file: tarballPath, C: dest, strip: 1 });
-            }
-            catch (err) {
-                console.error(chalk.red(`Failed to extract tarball: ${tarballPath}\n${err.message}`));
-                throw err;
-            }
-            if (isVerbose) {
-                console.log(chalk.cyan(`Installed ${name} from ${tarballMeta.tarballUrl}${usedCache ? " (from cache)" : ""}`));
-            }
-            i++;
-            bar.update(i, { pkg: chalk.yellow(name) });
-            return;
-        }
-        const storePath = await ensureInStore(name, info.version, tarballMeta);
-        const linkPath = path.join(nodeModulesDir, name);
-        // Check if already installed and up-to-date
-        const installedPkgJson = path.join(linkPath, "package.json");
-        let skip = false;
-        try {
-            const data = await fs.readFile(installedPkgJson, "utf-8");
-            const pkg = JSON.parse(data);
-            if (pkg.version === info.version) {
-                skip = true;
-            }
-        }
-        catch { }
-        if (skip) {
-            // Already installed and up-to-date
-            i++;
-            bar.update(i, { pkg: chalk.yellow(name) });
-            return;
-        }
-        await safeRemove(linkPath);
-        const t0 = process.hrtime.bigint();
-        if (options.useSymlinks) {
-            try {
-                await fs.symlink(storePath, linkPath, "dir");
-            }
-            catch (err) {
-                console.warn(chalk.yellow(`⚠ Symlink failed for ${name}@${info.version} (${err.code || err.message}). Falling back to copy. This will be much slower!`));
-                await fs.cp(storePath, linkPath, { recursive: true });
-            }
-        }
-        else {
-            await fs.cp(storePath, linkPath, { recursive: true });
-        }
-        const t1 = process.hrtime.bigint();
-        if (isVerbose) {
-            const linkTime = Number(t1 - t0) / 1000000; // Convert to milliseconds
-            console.log(chalk.gray(`[TIMING] link/copy ${name}@${info.version}: ${linkTime.toFixed(2)}ms`));
-        }
-        // Run lifecycle scripts
-        const t2 = process.hrtime.bigint();
-        await runLifecycleScript(linkPath, "preinstall", name);
-        await runLifecycleScript(linkPath, "install", name);
-        await runLifecycleScript(linkPath, "postinstall", name);
-        const t3 = process.hrtime.bigint();
-        if (isVerbose) {
-            const lifecycleTime = Number(t3 - t2) / 1000000; // Convert to milliseconds
-            console.log(chalk.gray(`[TIMING] lifecycle ${name}@${info.version}: ${lifecycleTime.toFixed(2)}ms`));
-        }
-        i++;
-        bar.update(i, { pkg: chalk.yellow(name) });
+  } catch (err) {
+    if (err.code === "ENOENT") {
+      // No log for non-existent
+    } else {
+      throw err;
     }
-    // Run workers in parallel with concurrency limit
-    let idx = 0;
-    async function runBatch() {
-        const batch = [];
-        for (let c = 0; c < concurrency && idx < pkgsWithTarballs.length; c++, idx++) {
-            batch.push(worker(pkgsWithTarballs[idx]));
-        }
-        await Promise.all(batch);
-        if (idx < pkgsWithTarballs.length) {
-            await runBatch();
-        }
-    }
+  }
+}
+
+async function handleLocalDep(depName, depSpec, nodeModulesDir) {
+  const dest = path.join(nodeModulesDir, depName);
+  let src = depSpec.replace(/^(file:|link:)/, "");
+  src = path.resolve(process.cwd(), src);
+  try {
+    await fs.rm(dest, { recursive: true, force: true });
+  } catch {}
+  if (depSpec.startsWith("file:")) {
+    await fs.cp(src, dest, { recursive: true });
+    console.log(
+      chalk.cyan(`Copied local dependency ${depName} from ${src}`),
+    );
+  } else if (depSpec.startsWith("link:")) {
     try {
-        await runBatch();
+      await fs.symlink(src, dest, "dir");
+      console.log(
+        chalk.cyan(
+          `Symlinked local dependency ${depName} from ${src}`,
+        ),
+      );
+    } catch (err) {
+      if (err.code === "EPERM" || err.code === "EEXIST") {
+        await fs.cp(src, dest, { recursive: true });
+        console.log(
+          chalk.cyan(
+            `Copied local dependency ${depName} from ${src} (symlink not permitted)`,
+          ),
+        );
+      } else {
+        throw err;
+      }
     }
-    catch (err) {
-        bar && bar.stop();
-        console.log(boxen(chalk.red.bold('❌ Install failed!') + '\n' + chalk.gray(err.message), {
-            padding: 1,
-            margin: 1,
-            borderStyle: 'round',
-            borderColor: 'red',
-            backgroundColor: 'black',
-            align: 'center',
-        }));
-        process.exit(1);
-    }
-    bar.stop();
-    console.log(boxen(chalk.bold.green('✔ All packages installed!'), {
-        padding: 1,
-        margin: 1,
-        borderStyle: 'round',
-        borderColor: 'green',
-        backgroundColor: 'black',
-        align: 'center',
-    }));
+  }
 }
+
+async function parseGithubSpec(spec) {
+  // github:user/repo[#ref] or user/repo[#ref]
+  let m = spec.match(/^github:([^/]+)\/([^#]+)(#(.+))?$/);
+  if (!m) m = spec.match(/^([^/]+)\/([^#]+)(#(.+))?$/);
+  if (!m) return null;
+  const user = m[1], repo = m[2];
+  const explicitRef = m[4];
+
+  // If the user pinned an explicit ref (branch/tag/SHA), use it as-is and never
+  // silently replace it with a default-branch fallback. Otherwise, ask GitHub
+  // for the default and bundle the historical 'main'/'master' fallbacks so we
+  // can transparently support repos whose default branch is still 'master'.
+  let refCandidates;
+  if (explicitRef) {
+    refCandidates = [explicitRef];
+  } else {
+    const { getDefaultBranchCandidates } = require('./sshHelper');
+    refCandidates = await getDefaultBranchCandidates(user, repo);
+  }
+  const ref = refCandidates[0];
+
+  return {
+    tarballUrl: `https://codeload.github.com/${user}/${repo}/tar.gz/${ref}`,
+    sshUrl: `git@github.com:${user}/${repo}.git`,
+    name: repo,
+    ref,
+    refCandidates,
+    explicitPinned: !!explicitRef,
+    user,
+  };
+}
+
+function isTarballUrl(spec) {
+  return /^https?:\/\/.+\.(tgz|tar\.gz)$/.test(spec);
+}
+
+async function downloadWithRetry(url, dest, headers = {}, maxRetries = 3) {
+  const axiosOpts = { responseType: "stream", headers };
+  let lastErr;
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    try {
+      const response = await axios.get(url, axiosOpts);
+      const writer = require("fs").createWriteStream(dest);
+      await new Promise((resolve, reject) => {
+        response.data.pipe(writer);
+        writer.on("finish", resolve);
+        writer.on("error", reject);
+      });
+      return true;
+    } catch (err) {
+      lastErr = err;
+      if (attempt < maxRetries) {
+        console.warn(chalk.yellow(`Download failed (attempt ${attempt}): ${err.message}. Retrying...`));
+        await new Promise(r => setTimeout(r, 1000 * attempt));
+      }
+    }
+  }
+  throw lastErr;
+}
+
+const { downloadWithSSH, getGitHubAuthHeaders } = require('./sshHelper');
+
+async function validateGithubOrTarballSpec(spec) {
+  if (isTarballUrl(spec)) return true;
+  const gh = await parseGithubSpec(spec);
+  if (gh) return true;
+  return false;
+}
+
+function sanitizePackageDirName(name) {
+  // Replace /, :, #, @, and any non-alphanumeric with -
+  return name.replace(/[^a-zA-Z0-9._-]/g, "-");
+}
+
+const isVerbose = process.argv.includes('--verbose');
+
+
+
+async function installTree(tree, destDir, options = {}) {
+  const nodeModulesDir = path.join(destDir, "node_modules");
+  await fs.mkdir(nodeModulesDir, { recursive: true });
+  const pkgs = Object.entries(tree);
+  const bar = new cliProgress.SingleBar({
+    format: '{bar} {percentage}% | {value}/{total} 📦',
+    barCompleteChar: '█',
+    barIncompleteChar: '░',
+      hideCursor: true,
+    linewrap: false,
+    clearOnComplete: false,
+    barsize: 30,
+  }, cliProgress.Presets.shades_classic);
+  bar.start(pkgs.length, 0, { pkg: "" });
+
+  const concurrency = 8;
+  let i = 0;
+
+  // Step 1: Resolve all tarball URLs in parallel
+  const pkgsWithTarballs = await Promise.all(
+    pkgs.map(async ([name, info]) => {
+      if (
+        info.version &&
+        (info.version.startsWith("file:") || info.version.startsWith("link:"))
+      ) {
+        return {
+          name,
+          info,
+          tarballMeta: {
+            tarballUrl: null,
+            shasum: null,
+            integrity: null,
+            signature: null,
+          },
+        };
+      }
+      // Handle GitHub and tarball URLs
+      if (isTarballUrl(info.version)) {
+        return { name, info, tarballMeta: { tarballUrl: info.version } };
+      }
+      const gh = await parseGithubSpec(info.version);
+      if (gh) {
+        return { name, info, tarballMeta: gh };
+      }
+      // Check if this is an npm alias
+      let packageNameForTarball = name;
+      if (info._alias && info._realPackage) {
+        packageNameForTarball = info._realPackage;
+      }
+      const tarballMeta = await getTarballUrl(packageNameForTarball, info.version);
+      return { name, info, tarballMeta };
+    }),
+  );
+
+  async function worker({ name, info, tarballMeta }) {
+    bar.update(i, { pkg: chalk.yellow(name) });
+    // Handle file: and link: dependencies
+    if (!tarballMeta.tarballUrl) {
+      await handleLocalDep(name, info.version, nodeModulesDir);
+      i++;
+      bar.update(i, { pkg: chalk.yellow(name) });
+      return;
+    }
+    // Only handle GitHub/tarball install if info.version is a GitHub/tarball spec
+    const gh = await parseGithubSpec(info.version);
+    const isGithubOrTarball = isTarballUrl(info.version) || (gh !== null);
+    if (isGithubOrTarball && (isTarballUrl(tarballMeta.tarballUrl) || tarballMeta.tarballUrl.includes('codeload.github.com'))) {
+      // Validate spec
+      if (!(await validateGithubOrTarballSpec(info.version))) {
+        console.error(chalk.red(`Invalid GitHub/tarball spec: '${info.version}'.\nExamples: user/repo, user/repo#branch, github:user/repo#sha, https://example.com/pkg.tgz`));
+        throw new Error(`Invalid GitHub/tarball spec: ${info.version}`);
+      }
+      const safeName = sanitizePackageDirName(name);
+      const dest = path.join(nodeModulesDir, safeName);
+      await safeRemove(dest);
+      await fs.mkdir(dest, { recursive: true });
+      await fs.mkdir(TARBALL_CACHE_DIR, { recursive: true });
+      // Auth context (shared across all candidate attempts and the direct
+      // tarball path — branch choice doesn't affect auth headers).
+      let headers = {};
+      let useSSH = false;
+      if (tarballMeta.tarballUrl.includes('codeload.github.com')) {
+        const auth = await getGitHubAuthHeaders();
+        if (auth.useSSH) {
+          useSSH = true;
+        } else if (auth.Authorization) {
+          headers = auth;
+        }
+      }
+
+      const crypto = require("crypto");
+
+      // We only enter the multi-branch fallback loop when this is a real
+      // GitHub spec (parseGithubSpec populated refCandidates + user/name).
+      // For raw tarball URLs (info.version = https://.../*.tgz) the
+      // tarballUrl IS the source of truth and refCandidates/user/name are
+      // absent — we must NOT overwrite it with a candidate-built URL.
+      const isGithubSpec =
+        !!tarballMeta.user &&
+        !!tarballMeta.name &&
+        Array.isArray(tarballMeta.refCandidates) &&
+        tarballMeta.refCandidates.length > 0;
+
+      let tarballPath = null;
+      let usedCache = false;
+
+      // Helper: drop a partial / zero-byte cache file left behind by an
+      // earlier failed download so the next attempt doesn't treat it as a
+      // valid cache hit.
+      const dropStalePartial = async (p) => {
+        try {
+          const st = await fs.stat(p);
+          if (st.size === 0) await fs.unlink(p);
+        } catch {}
+      };
+
+      if (isGithubSpec) {
+        // GitHub spec — try each candidate branch in priority order and stop
+        // at the first one that succeeds. HTTP 404 (and SSH clone failures,
+        // see below) are treated as "branch missing" and trigger the next
+        // candidate (issue #11: many repos like apache-superset/superset-
+        // frontend still default to 'master').
+        const candidates = tarballMeta.refCandidates;
+        const explicitPinned = !!tarballMeta.explicitPinned;
+        let downloaded = false;
+        let lastErr = null;
+
+        for (const candidateRef of candidates) {
+          const candidateTarballUrl =
+            `https://codeload.github.com/${tarballMeta.user}/${tarballMeta.name}/tar.gz/${candidateRef}`;
+          const candidateUrlHash =
+            crypto.createHash("sha1").update(candidateTarballUrl).digest("hex");
+          const candidateTarballPath =
+            path.join(TARBALL_CACHE_DIR, `${name}-${candidateUrlHash}.tar.gz`);
+
+          // Cache check: only treat non-empty files as hits; drop stale
+          // partial files from a prior failed download before proceeding.
+          await dropStalePartial(candidateTarballPath);
+          if (await fs.stat(candidateTarballPath).then(() => true, () => false)) {
+            tarballPath = candidateTarballPath;
+            tarballMeta.ref = candidateRef;
+            tarballMeta.tarballUrl = candidateTarballUrl;
+            usedCache = true;
+            downloaded = true;
+            break;
+          }
+
+          try {
+            if (useSSH && tarballMeta.sshUrl) {
+              // Use SSH to clone and create tarball
+              await downloadWithSSH(tarballMeta.sshUrl, candidateRef, candidateTarballPath, isVerbose);
+            } else {
+              await downloadWithRetry(candidateTarballUrl, candidateTarballPath, headers, 3);
+            }
+            tarballPath = candidateTarballPath;
+            tarballMeta.ref = candidateRef;
+            tarballMeta.tarballUrl = candidateTarballUrl;
+            usedCache = false;
+            downloaded = true;
+            if (!explicitPinned && candidates.length > 1) {
+              console.log(chalk.cyan(
+                `[${name}] Resolved default branch for ${info.version}: ${candidateRef}`
+              ));
+            }
+            break;
+          } catch (err) {
+            lastErr = err;
+            // Clean up any partial tarball before continuing/rethrowing.
+            await fs.unlink(candidateTarballPath).catch(() => {});
+            if (useSSH) {
+              // The git CLI doesn't surface a parseable "branch missing" error
+              // through the current spawn wiring, so for SSH we fall through
+              // to the next candidate on any failure when one is available,
+              // then rethrow the last error if all candidates are exhausted.
+              if (candidates.length > 1) {
+                console.warn(chalk.yellow(
+                  `[${name}] SSH attempt for ref '${candidateRef}' failed, trying next candidate.`
+                ));
+                continue;
+              }
+              throw err;
+            }
+            const is404 = err.response && err.response.status === 404;
+            if (is404 && candidates.length > 1) {
+              console.warn(chalk.yellow(
+                `[${name}] Ref '${candidateRef}' not found, trying next candidate.`
+              ));
+              continue;
+            }
+            if (tarballMeta.tarballUrl.includes('codeload.github.com')) {
+              if (!process.env.GITHUB_TOKEN) {
+                console.error(chalk.red(`Failed to download from GitHub. For private repos, either:`));
+                console.error(chalk.red(`  1. Set GITHUB_TOKEN env var with a personal access token, or`));
+                console.error(chalk.red(`  2. Add your SSH key with 'ssh-add' for SSH authentication`));
+              }
+            }
+            if (err.response && (err.response.status === 403 || err.response.status === 404)) {
+              console.error(chalk.red(`HTTP ${err.response.status} for ${candidateTarballUrl}. Check repo access or token.`));
+            }
+            throw err;
+          }
+        }
+
+        if (!downloaded) {
+          throw lastErr || new Error(
+            `Could not resolve a valid branch for ${info.version}`
+          );
+        }
+      } else {
+        // Raw tarball URL (or other non-GitHub-spec path). Single direct
+        // download — preserves today's behaviour for `blaze install https://.../*.tgz`.
+        const directUrl = tarballMeta.tarballUrl;
+        const directHash =
+          crypto.createHash("sha1").update(directUrl).digest("hex");
+        const directTarballPath =
+          path.join(TARBALL_CACHE_DIR, `${name}-${directHash}.tar.gz`);
+
+        await dropStalePartial(directTarballPath);
+        if (await fs.stat(directTarballPath).then(() => true, () => false)) {
+          tarballPath = directTarballPath;
+          usedCache = true;
+        } else {
+          try {
+            if (useSSH && tarballMeta.sshUrl) {
+              await downloadWithSSH(tarballMeta.sshUrl, tarballMeta.ref, directTarballPath, isVerbose);
+            } else {
+              await downloadWithRetry(directUrl, directTarballPath, headers, 3);
+            }
+            tarballPath = directTarballPath;
+            usedCache = false;
+          } catch (err) {
+            await fs.unlink(directTarballPath).catch(() => {});
+            if (directUrl.includes('codeload.github.com')) {
+              if (!process.env.GITHUB_TOKEN) {
+                console.error(chalk.red(`Failed to download from GitHub. For private repos, either:`));
+                console.error(chalk.red(`  1. Set GITHUB_TOKEN env var with a personal access token, or`));
+                console.error(chalk.red(`  2. Add your SSH key with 'ssh-add' for SSH authentication`));
+              }
+            }
+            if (err.response && (err.response.status === 403 || err.response.status === 404)) {
+              console.error(chalk.red(`HTTP ${err.response.status} for ${directUrl}. Check repo access or token.`));
+            }
+            throw err;
+          }
+        }
+      }
+      // Extract
+      const tar = require("tar");
+      try {
+        await tar.x({ file: tarballPath, C: dest, strip: 1 });
+      } catch (err) {
+        console.error(chalk.red(`Failed to extract tarball: ${tarballPath}\n${err.message}`));
+        throw err;
+      }
+      if (isVerbose) {
+        console.log(chalk.cyan(`Installed ${name} from ${tarballMeta.tarballUrl}${usedCache ? " (from cache)" : ""}`));
+      }
+      i++;
+      bar.update(i, { pkg: chalk.yellow(name) });
+      return;
+    }
+    const storePath = await ensureInStore(name, info.version, tarballMeta);
+    const linkPath = path.join(nodeModulesDir, name);
+    // Check if already installed and up-to-date
+    const installedPkgJson = path.join(linkPath, "package.json");
+    let skip = false;
+    try {
+      const data = await fs.readFile(installedPkgJson, "utf-8");
+      const pkg = JSON.parse(data);
+      if (pkg.version === info.version) {
+        skip = true;
+      }
+    } catch {}
+    if (skip) {
+      // Already installed and up-to-date
+      i++;
+      bar.update(i, { pkg: chalk.yellow(name) });
+      return;
+    }
+    await safeRemove(linkPath);
+    const t0 = process.hrtime.bigint();
+    if (options.useSymlinks) {
+      try {
+        await fs.symlink(storePath, linkPath, "dir");
+      } catch (err) {
+        console.warn(chalk.yellow(`⚠ Symlink failed for ${name}@${info.version} (${err.code || err.message}). Falling back to copy. This will be much slower!`));
+        await fs.cp(storePath, linkPath, { recursive: true });
+      }
+    } else {
+      await fs.cp(storePath, linkPath, { recursive: true });
+    }
+    const t1 = process.hrtime.bigint();
+    if (isVerbose) {
+      const linkTime = Number(t1 - t0) / 1_000_000; // Convert to milliseconds
+      console.log(chalk.gray(`[TIMING] link/copy ${name}@${info.version}: ${linkTime.toFixed(2)}ms`));
+    }
+    // Run lifecycle scripts
+    const t2 = process.hrtime.bigint();
+    await runLifecycleScript(linkPath, "preinstall", name);
+    await runLifecycleScript(linkPath, "install", name);
+    await runLifecycleScript(linkPath, "postinstall", name);
+    const t3 = process.hrtime.bigint();
+    if (isVerbose) {
+      const lifecycleTime = Number(t3 - t2) / 1_000_000; // Convert to milliseconds
+      console.log(chalk.gray(`[TIMING] lifecycle ${name}@${info.version}: ${lifecycleTime.toFixed(2)}ms`));
+    }
+    i++;
+    bar.update(i, { pkg: chalk.yellow(name) });
+  }
+
+  // Run workers in parallel with concurrency limit
+  let idx = 0;
+  async function runBatch() {
+    const batch = [];
+    for (
+      let c = 0;
+      c < concurrency && idx < pkgsWithTarballs.length;
+      c++, idx++
+    ) {
+      batch.push(worker(pkgsWithTarballs[idx]));
+    }
+    await Promise.all(batch);
+    if (idx < pkgsWithTarballs.length) {
+      await runBatch();
+    }
+  }
+  try {
+  await runBatch();
+  } catch (err) {
+    bar && bar.stop();
+    console.log(boxen(chalk.red.bold('❌ Install failed!') + '\n' + chalk.gray(err.message), {
+      padding: 1,
+      margin: 1,
+      borderStyle: 'round',
+      borderColor: 'red',
+      backgroundColor: 'black',
+      align: 'center',
+    }));
+    process.exit(1);
+  }
+
+  bar.stop();
+  console.log(boxen(chalk.bold.green('✔ All packages installed!'), {
+    padding: 1,
+    margin: 1,
+    borderStyle: 'round',
+    borderColor: 'green',
+    backgroundColor: 'black',
+    align: 'center',
+  }));
+}
+
 module.exports = { installTree, runLifecycleScript };

--- a/lib/sshHelper.js
+++ b/lib/sshHelper.js
@@ -1,10 +1,10 @@
-"use strict";
 const { execSync, spawn } = require('child_process');
 const os = require('os');
 const path = require('path');
 const fs = require('fs').promises;
 const crypto = require('crypto');
 const axios = require('axios');
+
 /**
  * Download a GitHub repository using SSH and create a tarball
  * @param {string} sshUrl - SSH URL of the repository
@@ -14,162 +14,204 @@ const axios = require('axios');
  * @returns {Promise<void>}
  */
 async function downloadWithSSH(sshUrl, ref, dest, isVerbose = false) {
-    // Use crypto.randomBytes for safer uniqueness than Date.now()
-    const randomSuffix = crypto.randomBytes(8).toString('hex');
-    const tempDir = path.join(os.tmpdir(), `blaze-ssh-${randomSuffix}`);
+  // Use crypto.randomBytes for safer uniqueness than Date.now()
+  const randomSuffix = crypto.randomBytes(8).toString('hex');
+  const tempDir = path.join(os.tmpdir(), `blaze-ssh-${randomSuffix}`);
+  
+  try {
+    // Clone the repo using async spawn instead of blocking execSync
+    await new Promise((resolve, reject) => {
+      const cloneProcess = spawn('git', ['clone', '--depth', '1', '--branch', ref, sshUrl, tempDir], {
+        stdio: 'pipe'
+      });
+      
+      cloneProcess.on('close', (code) => {
+        if (code === 0) {
+          resolve();
+        } else {
+          reject(new Error(`Git clone failed with code ${code}`));
+        }
+      });
+      
+      cloneProcess.on('error', (err) => {
+        reject(new Error(`Git clone failed: ${err.message}`));
+      });
+    });
+    
+    // Create tarball using async spawn
+    await new Promise((resolve, reject) => {
+      const tarProcess = spawn('tar', ['-czf', dest, '-C', tempDir, '.'], {
+        stdio: 'pipe'
+      });
+      
+      tarProcess.on('close', (code) => {
+        if (code === 0) {
+          resolve();
+        } else {
+          reject(new Error(`Tar creation failed with code ${code}`));
+        }
+      });
+      
+      tarProcess.on('error', (err) => {
+        reject(new Error(`Tar creation failed: ${err.message}`));
+      });
+    });
+    
+    if (isVerbose) {
+      console.log(`Downloaded via SSH: ${sshUrl}#${ref}`);
+    }
+  } catch (err) {
+    // Provide more informative error messages
+    if (err.message.includes('git clone')) {
+      throw new Error(`Failed to clone repository ${sshUrl}: ${err.message}. Make sure your SSH key is added to ssh-agent and you have access to the repository.`);
+    } else if (err.message.includes('tar')) {
+      throw new Error(`Failed to create tarball from ${sshUrl}: ${err.message}`);
+    }
+    throw err;
+  } finally {
+    // Clean up temp directory
     try {
-        // Clone the repo using async spawn instead of blocking execSync
-        await new Promise((resolve, reject) => {
-            const cloneProcess = spawn('git', ['clone', '--depth', '1', '--branch', ref, sshUrl, tempDir], {
-                stdio: 'pipe'
-            });
-            cloneProcess.on('close', (code) => {
-                if (code === 0) {
-                    resolve();
-                }
-                else {
-                    reject(new Error(`Git clone failed with code ${code}`));
-                }
-            });
-            cloneProcess.on('error', (err) => {
-                reject(new Error(`Git clone failed: ${err.message}`));
-            });
-        });
-        // Create tarball using async spawn
-        await new Promise((resolve, reject) => {
-            const tarProcess = spawn('tar', ['-czf', dest, '-C', tempDir, '.'], {
-                stdio: 'pipe'
-            });
-            tarProcess.on('close', (code) => {
-                if (code === 0) {
-                    resolve();
-                }
-                else {
-                    reject(new Error(`Tar creation failed with code ${code}`));
-                }
-            });
-            tarProcess.on('error', (err) => {
-                reject(new Error(`Tar creation failed: ${err.message}`));
-            });
-        });
-        if (isVerbose) {
-            console.log(`Downloaded via SSH: ${sshUrl}#${ref}`);
-        }
+      await fs.rm(tempDir, { recursive: true, force: true });
+    } catch (err) {
+      // Ignore cleanup errors
     }
-    catch (err) {
-        // Provide more informative error messages
-        if (err.message.includes('git clone')) {
-            throw new Error(`Failed to clone repository ${sshUrl}: ${err.message}. Make sure your SSH key is added to ssh-agent and you have access to the repository.`);
-        }
-        else if (err.message.includes('tar')) {
-            throw new Error(`Failed to create tarball from ${sshUrl}: ${err.message}`);
-        }
-        throw err;
-    }
-    finally {
-        // Clean up temp directory
-        try {
-            await fs.rm(tempDir, { recursive: true, force: true });
-        }
-        catch (err) {
-            // Ignore cleanup errors
-        }
-    }
+  }
 }
+
 /**
  * Get GitHub authentication headers (supports both token and SSH)
  * @returns {Promise<Object>} Headers object or { useSSH: true } for SSH
  */
 async function getGitHubAuthHeaders() {
-    const headers = {};
-    // First try GITHUB_TOKEN
-    const token = process.env.GITHUB_TOKEN;
-    if (token) {
-        headers['Authorization'] = `token ${token}`;
-        return headers;
-    }
-    // Then try SSH key authentication
-    const hasKeys = await hasSSHKeys();
-    if (hasKeys) {
-        // SSH key is available, use SSH URL instead of HTTPS
-        return { useSSH: true };
-    }
+  const headers = {};
+  
+  // First try GITHUB_TOKEN
+  const token = process.env.GITHUB_TOKEN;
+  if (token) {
+    headers['Authorization'] = `token ${token}`;
     return headers;
+  }
+  
+  // Then try SSH key authentication
+  const hasKeys = await hasSSHKeys();
+  if (hasKeys) {
+    // SSH key is available, use SSH URL instead of HTTPS
+    return { useSSH: true };
+  }
+  
+  return headers;
 }
+
 /**
  * Check if SSH keys exist in the user's .ssh directory
  * @returns {Promise<boolean>} True if SSH keys are found
  */
 async function hasSSHKeys() {
-    const sshDir = path.join(os.homedir(), '.ssh');
-    try {
-        // Check if .ssh directory exists
-        await fs.access(sshDir);
-        // Look for common SSH key files
-        const keyFiles = [
-            'id_rsa',
-            'id_ed25519',
-            'id_ecdsa',
-            'id_dsa'
-        ];
-        for (const keyFile of keyFiles) {
-            try {
-                await fs.access(path.join(sshDir, keyFile));
-                return true; // Found at least one SSH key
-            }
-            catch {
-                // Key file doesn't exist, continue checking others
-            }
-        }
-        // Also check for keys with .pub extension
-        const pubKeyFiles = [
-            'id_rsa.pub',
-            'id_ed25519.pub',
-            'id_ecdsa.pub',
-            'id_dsa.pub'
-        ];
-        for (const pubKeyFile of pubKeyFiles) {
-            try {
-                await fs.access(path.join(sshDir, pubKeyFile));
-                return true; // Found at least one SSH public key
-            }
-            catch {
-                // Key file doesn't exist, continue checking others
-            }
-        }
-        return false; // No SSH keys found
+  const sshDir = path.join(os.homedir(), '.ssh');
+  
+  try {
+    // Check if .ssh directory exists
+    await fs.access(sshDir);
+    
+    // Look for common SSH key files
+    const keyFiles = [
+      'id_rsa',
+      'id_ed25519', 
+      'id_ecdsa',
+      'id_dsa'
+    ];
+    
+    for (const keyFile of keyFiles) {
+      try {
+        await fs.access(path.join(sshDir, keyFile));
+        return true; // Found at least one SSH key
+      } catch {
+        // Key file doesn't exist, continue checking others
+      }
     }
-    catch {
-        // .ssh directory doesn't exist
-        return false;
+    
+    // Also check for keys with .pub extension
+    const pubKeyFiles = [
+      'id_rsa.pub',
+      'id_ed25519.pub',
+      'id_ecdsa.pub', 
+      'id_dsa.pub'
+    ];
+    
+    for (const pubKeyFile of pubKeyFiles) {
+      try {
+        await fs.access(path.join(sshDir, pubKeyFile));
+        return true; // Found at least one SSH public key
+      } catch {
+        // Key file doesn't exist, continue checking others
+      }
     }
+    
+    return false; // No SSH keys found
+  } catch {
+    // .ssh directory doesn't exist
+    return false;
+  }
 }
+
 /**
- * Get the default branch for a GitHub repository
+ * Get candidate default branches for a GitHub repository, in priority order.
+ * Resolves the API-reported default branch first (if reachable), then falls
+ * back to the historical defaults 'main' and 'master'. Issue #11: many repos
+ * (e.g. apache-superset/superset-frontend) still use 'master' as their default.
+ *
+ * @param {string} user - GitHub username
+ * @param {string} repo - Repository name
+ * @returns {Promise<string[]>} Ordered, deduplicated list of branch candidates
+ */
+async function getDefaultBranchCandidates(user, repo) {
+  const FALLBACKS = ['main', 'master'];
+  try {
+    // Try to get default branch from GitHub API
+    const headers = {};
+    const token = process.env.GITHUB_TOKEN;
+    if (token) {
+      headers['Authorization'] = `token ${token}`;
+    }
+
+    const response = await axios.get(
+      `https://api.github.com/repos/${user}/${repo}`,
+      { headers }
+    );
+    const detected = response.data && response.data.default_branch;
+    const candidates = [];
+    if (detected) candidates.push(detected);
+    for (const fb of FALLBACKS) {
+      if (fb && !candidates.includes(fb)) candidates.push(fb);
+    }
+    return candidates.length > 0 ? candidates : FALLBACKS.slice();
+  } catch (err) {
+    // If the API call fails, fall back to the historical defaults in order.
+    console.warn(
+      `Warning: Could not determine default branch for ${user}/${repo}; ` +
+      `will try 'main' and 'master' as fallbacks.`
+    );
+    return FALLBACKS.slice();
+  }
+}
+
+/**
+ * Get the default branch for a GitHub repository (single string).
+ * Backwards-compatible wrapper around getDefaultBranchCandidates.
+ *
  * @param {string} user - GitHub username
  * @param {string} repo - Repository name
  * @returns {Promise<string>} Default branch name
  */
 async function getDefaultBranch(user, repo) {
-    try {
-        // Try to get default branch from GitHub API
-        const headers = {};
-        const token = process.env.GITHUB_TOKEN;
-        if (token) {
-            headers['Authorization'] = `token ${token}`;
-        }
-        const response = await axios.get(`https://api.github.com/repos/${user}/${repo}`, { headers });
-        return response.data.default_branch || 'main';
-    }
-    catch (err) {
-        // If API call fails, fall back to 'main' as default
-        console.warn(`Warning: Could not determine default branch for ${user}/${repo}, using 'main' as fallback`);
-        return 'main';
-    }
+  const candidates = await getDefaultBranchCandidates(user, repo);
+  return candidates[0];
 }
+
 module.exports = {
-    downloadWithSSH,
-    getGitHubAuthHeaders,
-    hasSSHKeys,
-    getDefaultBranch
-};
+  downloadWithSSH,
+  getGitHubAuthHeaders,
+  hasSSHKeys,
+  getDefaultBranch,
+  getDefaultBranchCandidates
+}; 

--- a/src/installTree.js
+++ b/src/installTree.js
@@ -152,19 +152,28 @@ async function parseGithubSpec(spec) {
   if (!m) m = spec.match(/^([^/]+)\/([^#]+)(#(.+))?$/);
   if (!m) return null;
   const user = m[1], repo = m[2];
-  let ref = m[4];
-  
-  // If no ref specified, get the default branch from GitHub
-  if (!ref) {
-    const { getDefaultBranch } = require('./sshHelper');
-    ref = await getDefaultBranch(user, repo);
+  const explicitRef = m[4];
+
+  // If the user pinned an explicit ref (branch/tag/SHA), use it as-is and never
+  // silently replace it with a default-branch fallback. Otherwise, ask GitHub
+  // for the default and bundle the historical 'main'/'master' fallbacks so we
+  // can transparently support repos whose default branch is still 'master'.
+  let refCandidates;
+  if (explicitRef) {
+    refCandidates = [explicitRef];
+  } else {
+    const { getDefaultBranchCandidates } = require('./sshHelper');
+    refCandidates = await getDefaultBranchCandidates(user, repo);
   }
-  
+  const ref = refCandidates[0];
+
   return {
     tarballUrl: `https://codeload.github.com/${user}/${repo}/tar.gz/${ref}`,
     sshUrl: `git@github.com:${user}/${repo}.git`,
     name: repo,
     ref,
+    refCandidates,
+    explicitPinned: !!explicitRef,
     user,
   };
 }
@@ -292,46 +301,173 @@ async function installTree(tree, destDir, options = {}) {
       await safeRemove(dest);
       await fs.mkdir(dest, { recursive: true });
       await fs.mkdir(TARBALL_CACHE_DIR, { recursive: true });
-      // Cache tarball by URL hash
+      // Auth context (shared across all candidate attempts and the direct
+      // tarball path — branch choice doesn't affect auth headers).
+      let headers = {};
+      let useSSH = false;
+      if (tarballMeta.tarballUrl.includes('codeload.github.com')) {
+        const auth = await getGitHubAuthHeaders();
+        if (auth.useSSH) {
+          useSSH = true;
+        } else if (auth.Authorization) {
+          headers = auth;
+        }
+      }
+
       const crypto = require("crypto");
-      const urlHash = crypto.createHash("sha1").update(tarballMeta.tarballUrl).digest("hex");
-      const tarballPath = path.join(TARBALL_CACHE_DIR, `${name}-${urlHash}.tar.gz`);
+
+      // We only enter the multi-branch fallback loop when this is a real
+      // GitHub spec (parseGithubSpec populated refCandidates + user/name).
+      // For raw tarball URLs (info.version = https://.../*.tgz) the
+      // tarballUrl IS the source of truth and refCandidates/user/name are
+      // absent — we must NOT overwrite it with a candidate-built URL.
+      const isGithubSpec =
+        !!tarballMeta.user &&
+        !!tarballMeta.name &&
+        Array.isArray(tarballMeta.refCandidates) &&
+        tarballMeta.refCandidates.length > 0;
+
+      let tarballPath = null;
       let usedCache = false;
-      if (await fs.stat(tarballPath).then(() => true, () => false)) {
-        usedCache = true;
-      } else {
-        // Download with retry and auth if needed
-        let headers = {};
-        let useSSH = false;
-        
-        if (tarballMeta.tarballUrl.includes('codeload.github.com')) {
-          const auth = await getGitHubAuthHeaders();
-          if (auth.useSSH) {
-            useSSH = true;
-          } else if (auth.Authorization) {
-            headers = auth;
+
+      // Helper: drop a partial / zero-byte cache file left behind by an
+      // earlier failed download so the next attempt doesn't treat it as a
+      // valid cache hit.
+      const dropStalePartial = async (p) => {
+        try {
+          const st = await fs.stat(p);
+          if (st.size === 0) await fs.unlink(p);
+        } catch {}
+      };
+
+      if (isGithubSpec) {
+        // GitHub spec — try each candidate branch in priority order and stop
+        // at the first one that succeeds. HTTP 404 (and SSH clone failures,
+        // see below) are treated as "branch missing" and trigger the next
+        // candidate (issue #11: many repos like apache-superset/superset-
+        // frontend still default to 'master').
+        const candidates = tarballMeta.refCandidates;
+        const explicitPinned = !!tarballMeta.explicitPinned;
+        let downloaded = false;
+        let lastErr = null;
+
+        for (const candidateRef of candidates) {
+          const candidateTarballUrl =
+            `https://codeload.github.com/${tarballMeta.user}/${tarballMeta.name}/tar.gz/${candidateRef}`;
+          const candidateUrlHash =
+            crypto.createHash("sha1").update(candidateTarballUrl).digest("hex");
+          const candidateTarballPath =
+            path.join(TARBALL_CACHE_DIR, `${name}-${candidateUrlHash}.tar.gz`);
+
+          // Cache check: only treat non-empty files as hits; drop stale
+          // partial files from a prior failed download before proceeding.
+          await dropStalePartial(candidateTarballPath);
+          if (await fs.stat(candidateTarballPath).then(() => true, () => false)) {
+            tarballPath = candidateTarballPath;
+            tarballMeta.ref = candidateRef;
+            tarballMeta.tarballUrl = candidateTarballUrl;
+            usedCache = true;
+            downloaded = true;
+            break;
+          }
+
+          try {
+            if (useSSH && tarballMeta.sshUrl) {
+              // Use SSH to clone and create tarball
+              await downloadWithSSH(tarballMeta.sshUrl, candidateRef, candidateTarballPath, isVerbose);
+            } else {
+              await downloadWithRetry(candidateTarballUrl, candidateTarballPath, headers, 3);
+            }
+            tarballPath = candidateTarballPath;
+            tarballMeta.ref = candidateRef;
+            tarballMeta.tarballUrl = candidateTarballUrl;
+            usedCache = false;
+            downloaded = true;
+            if (!explicitPinned && candidates.length > 1) {
+              console.log(chalk.cyan(
+                `[${name}] Resolved default branch for ${info.version}: ${candidateRef}`
+              ));
+            }
+            break;
+          } catch (err) {
+            lastErr = err;
+            // Clean up any partial tarball before continuing/rethrowing.
+            await fs.unlink(candidateTarballPath).catch(() => {});
+            if (useSSH) {
+              // The git CLI doesn't surface a parseable "branch missing" error
+              // through the current spawn wiring, so for SSH we fall through
+              // to the next candidate on any failure when one is available,
+              // then rethrow the last error if all candidates are exhausted.
+              if (candidates.length > 1) {
+                console.warn(chalk.yellow(
+                  `[${name}] SSH attempt for ref '${candidateRef}' failed, trying next candidate.`
+                ));
+                continue;
+              }
+              throw err;
+            }
+            const is404 = err.response && err.response.status === 404;
+            if (is404 && candidates.length > 1) {
+              console.warn(chalk.yellow(
+                `[${name}] Ref '${candidateRef}' not found, trying next candidate.`
+              ));
+              continue;
+            }
+            if (tarballMeta.tarballUrl.includes('codeload.github.com')) {
+              if (!process.env.GITHUB_TOKEN) {
+                console.error(chalk.red(`Failed to download from GitHub. For private repos, either:`));
+                console.error(chalk.red(`  1. Set GITHUB_TOKEN env var with a personal access token, or`));
+                console.error(chalk.red(`  2. Add your SSH key with 'ssh-add' for SSH authentication`));
+              }
+            }
+            if (err.response && (err.response.status === 403 || err.response.status === 404)) {
+              console.error(chalk.red(`HTTP ${err.response.status} for ${candidateTarballUrl}. Check repo access or token.`));
+            }
+            throw err;
           }
         }
-        
-        try {
-          if (useSSH && tarballMeta.sshUrl) {
-            // Use SSH to clone and create tarball
-            await downloadWithSSH(tarballMeta.sshUrl, tarballMeta.ref, tarballPath, isVerbose);
-          } else {
-            await downloadWithRetry(tarballMeta.tarballUrl, tarballPath, headers, 3);
-          }
-        } catch (err) {
-          if (tarballMeta.tarballUrl.includes('codeload.github.com')) {
-            if (!process.env.GITHUB_TOKEN) {
-              console.error(chalk.red(`Failed to download from GitHub. For private repos, either:`));
-              console.error(chalk.red(`  1. Set GITHUB_TOKEN env var with a personal access token, or`));
-              console.error(chalk.red(`  2. Add your SSH key with 'ssh-add' for SSH authentication`));
+
+        if (!downloaded) {
+          throw lastErr || new Error(
+            `Could not resolve a valid branch for ${info.version}`
+          );
+        }
+      } else {
+        // Raw tarball URL (or other non-GitHub-spec path). Single direct
+        // download — preserves today's behaviour for `blaze install https://.../*.tgz`.
+        const directUrl = tarballMeta.tarballUrl;
+        const directHash =
+          crypto.createHash("sha1").update(directUrl).digest("hex");
+        const directTarballPath =
+          path.join(TARBALL_CACHE_DIR, `${name}-${directHash}.tar.gz`);
+
+        await dropStalePartial(directTarballPath);
+        if (await fs.stat(directTarballPath).then(() => true, () => false)) {
+          tarballPath = directTarballPath;
+          usedCache = true;
+        } else {
+          try {
+            if (useSSH && tarballMeta.sshUrl) {
+              await downloadWithSSH(tarballMeta.sshUrl, tarballMeta.ref, directTarballPath, isVerbose);
+            } else {
+              await downloadWithRetry(directUrl, directTarballPath, headers, 3);
             }
+            tarballPath = directTarballPath;
+            usedCache = false;
+          } catch (err) {
+            await fs.unlink(directTarballPath).catch(() => {});
+            if (directUrl.includes('codeload.github.com')) {
+              if (!process.env.GITHUB_TOKEN) {
+                console.error(chalk.red(`Failed to download from GitHub. For private repos, either:`));
+                console.error(chalk.red(`  1. Set GITHUB_TOKEN env var with a personal access token, or`));
+                console.error(chalk.red(`  2. Add your SSH key with 'ssh-add' for SSH authentication`));
+              }
+            }
+            if (err.response && (err.response.status === 403 || err.response.status === 404)) {
+              console.error(chalk.red(`HTTP ${err.response.status} for ${directUrl}. Check repo access or token.`));
+            }
+            throw err;
           }
-          if (err.response && (err.response.status === 403 || err.response.status === 404)) {
-            console.error(chalk.red(`HTTP ${err.response.status} for ${tarballMeta.tarballUrl}. Check repo access or token.`));
-          }
-          throw err;
         }
       }
       // Extract

--- a/src/installTree.js
+++ b/src/installTree.js
@@ -208,11 +208,16 @@ async function downloadWithRetry(url, dest, headers = {}, maxRetries = 3) {
 
 const { downloadWithSSH, getGitHubAuthHeaders } = require('./sshHelper');
 
-async function validateGithubOrTarballSpec(spec) {
+async function validateGithubOrTarballSpec(spec, gh) {
+  // Cheap early-out for tarball URLs.
   if (isTarballUrl(spec)) return true;
-  const gh = await parseGithubSpec(spec);
-  if (gh) return true;
-  return false;
+  // If the caller already parsed the spec (e.g. worker has `tarballMeta`
+  // from the resolution phase), trust that result and skip the second
+  // parseGithubSpec call — it would otherwise hit the GitHub API again
+  // and increase install latency / rate-limit risk. Single-arg callers
+  // still get the old behaviour via the fallback below.
+  if (!gh) gh = await parseGithubSpec(spec);
+  return !!gh;
 }
 
 function sanitizePackageDirName(name) {
@@ -287,12 +292,24 @@ async function installTree(tree, destDir, options = {}) {
       bar.update(i, { pkg: chalk.yellow(name) });
       return;
     }
-    // Only handle GitHub/tarball install if info.version is a GitHub/tarball spec
-    const gh = await parseGithubSpec(info.version);
-    const isGithubOrTarball = isTarballUrl(info.version) || (gh !== null);
-    if (isGithubOrTarball && (isTarballUrl(tarballMeta.tarballUrl) || tarballMeta.tarballUrl.includes('codeload.github.com'))) {
-      // Validate spec
-      if (!(await validateGithubOrTarballSpec(info.version))) {
+    // Only handle GitHub/tarball install if info.version is a GitHub/tarball spec.
+    // Both `gh` and `isGithubOrTarball` are derived cheaply from `tarballMeta`
+    // (which the resolution phase already populated), so we avoid a redundant
+    // parseGithubSpec(info.version) call here — that would otherwise trigger
+    // a second GitHub API request per GitHub spec and burn rate-limit budget.
+    const gh = (tarballMeta && tarballMeta.user && tarballMeta.name)
+      ? tarballMeta
+      : null;
+    const isGithubOrTarball = !!tarballMeta.tarballUrl && (
+      isTarballUrl(tarballMeta.tarballUrl) ||
+      tarballMeta.tarballUrl.includes('codeload.github.com')
+    );
+    if (isGithubOrTarball) {
+      // Tertiary safety: validate cheaply using the already-parsed `gh`
+      // (no extra GitHub API call). The outer condition already established
+      // the spec is valid via `tarballMeta`, but this preserves the original
+      // error message for any unforeseen edge cases.
+      if (!(await validateGithubOrTarballSpec(info.version, gh))) {
         console.error(chalk.red(`Invalid GitHub/tarball spec: '${info.version}'.\nExamples: user/repo, user/repo#branch, github:user/repo#sha, https://example.com/pkg.tgz`));
         throw new Error(`Invalid GitHub/tarball spec: ${info.version}`);
       }
@@ -470,11 +487,14 @@ async function installTree(tree, destDir, options = {}) {
           }
         }
       }
-      // Extract
+      // Extract. Drop the on-disk tarball on extract failure so the next
+      // run doesn't treat a corrupted/half-extracted package as a cache hit
+      // and silently ship a broken node_modules entry.
       const tar = require("tar");
       try {
         await tar.x({ file: tarballPath, C: dest, strip: 1 });
       } catch (err) {
+        await fs.unlink(tarballPath).catch(() => {});
         console.error(chalk.red(`Failed to extract tarball: ${tarballPath}\n${err.message}`));
         throw err;
       }

--- a/src/sshHelper.js
+++ b/src/sshHelper.js
@@ -155,12 +155,17 @@ async function hasSSHKeys() {
 }
 
 /**
- * Get the default branch for a GitHub repository
+ * Get candidate default branches for a GitHub repository, in priority order.
+ * Resolves the API-reported default branch first (if reachable), then falls
+ * back to the historical defaults 'main' and 'master'. Issue #11: many repos
+ * (e.g. apache-superset/superset-frontend) still use 'master' as their default.
+ *
  * @param {string} user - GitHub username
  * @param {string} repo - Repository name
- * @returns {Promise<string>} Default branch name
+ * @returns {Promise<string[]>} Ordered, deduplicated list of branch candidates
  */
-async function getDefaultBranch(user, repo) {
+async function getDefaultBranchCandidates(user, repo) {
+  const FALLBACKS = ['main', 'master'];
   try {
     // Try to get default branch from GitHub API
     const headers = {};
@@ -168,19 +173,45 @@ async function getDefaultBranch(user, repo) {
     if (token) {
       headers['Authorization'] = `token ${token}`;
     }
-    
-    const response = await axios.get(`https://api.github.com/repos/${user}/${repo}`, { headers });
-    return response.data.default_branch || 'main';
+
+    const response = await axios.get(
+      `https://api.github.com/repos/${user}/${repo}`,
+      { headers }
+    );
+    const detected = response.data && response.data.default_branch;
+    const candidates = [];
+    if (detected) candidates.push(detected);
+    for (const fb of FALLBACKS) {
+      if (fb && !candidates.includes(fb)) candidates.push(fb);
+    }
+    return candidates.length > 0 ? candidates : FALLBACKS.slice();
   } catch (err) {
-    // If API call fails, fall back to 'main' as default
-    console.warn(`Warning: Could not determine default branch for ${user}/${repo}, using 'main' as fallback`);
-    return 'main';
+    // If the API call fails, fall back to the historical defaults in order.
+    console.warn(
+      `Warning: Could not determine default branch for ${user}/${repo}; ` +
+      `will try 'main' and 'master' as fallbacks.`
+    );
+    return FALLBACKS.slice();
   }
+}
+
+/**
+ * Get the default branch for a GitHub repository (single string).
+ * Backwards-compatible wrapper around getDefaultBranchCandidates.
+ *
+ * @param {string} user - GitHub username
+ * @param {string} repo - Repository name
+ * @returns {Promise<string>} Default branch name
+ */
+async function getDefaultBranch(user, repo) {
+  const candidates = await getDefaultBranchCandidates(user, repo);
+  return candidates[0];
 }
 
 module.exports = {
   downloadWithSSH,
   getGitHubAuthHeaders,
   hasSSHKeys,
-  getDefaultBranch
+  getDefaultBranch,
+  getDefaultBranchCandidates
 }; 


### PR DESCRIPTION
## Summary
Closes #11 — `blaze install apache-superset/superset-frontend` (and similar repos whose default branch is `master`) now resolves correctly instead of silently trying only `main`.

## Root cause
`src/sshHelper.js#getDefaultBranch` was hard-coded to fall back to `'main'` when the GitHub REST call failed (rate limit, offline, or a private repo with no token). For a repo whose real default is `master`, that produced a codeload tarball request `.../tar.gz/main` and got a 404.

## Approach: candidate-list fallback
The resolver now returns an **ordered, deduplicated candidate list**, and the install worker iterates it.

- `getDefaultBranchCandidates(user, repo)` returns `[detected?, 'main', 'master']` when the API succeeds, or `['main', 'master']` when it fails.
- `parseGithubSpec(spec)` stores the list as `tarballMeta.refCandidates` plus an `explicitPinned` flag — so `user/repo#feature` is *never* silently replaced.
- The install worker falls through on HTTP 404 or SSH clone failure, stopping at the first success. SSH deliberately tries the next candidate on any failure because the current spawn wiring cannot parse "Remote branch ... not found" from stderr.

## Files changed
- `src/sshHelper.js` — added exported `getDefaultBranchCandidates`; kept `getDefaultBranch` as a back-compat wrapper returning `candidates[0]`.
- `src/installTree.js`:
  - `parseGithubSpec` now populates `refCandidates` and `explicitPinned`.
  - Worker download block gates the candidate loop on `isGithubSpec`, so raw `https://.../*.tgz` URLs take the unchanged direct-download path.
  - Drops zero-byte partial cache files before the cache check, and unlinks the candidate tarball on every catch so partial files do not leak.
- `lib/{sshHelper,installTree}.js` — regenerated to mirror `src/` (this repo commits compiled JS).

## Test plan
- [ ] `blaze install apache-superset/superset-frontend` succeeds on the default branch (`master`).
- [ ] `blaze install user/repo#non-existent-branch` fails loudly with a 404, never silently substitutes `main`/`master`.
- [ ] `blaze install https://example.com/foo.tgz` keeps today's single-attempt behavior; verify no fabricated codeload URL appears in the logs.
- [ ] Manually pre-stage a 0-byte file at `~/.blaze_cache/tarballs/<name>-<sha1-of-tarballUrl>.tar.gz` and confirm the next install re-downloads rather than treating it as a cache hit.

## Risk
Low. The candidate loop is gated on `isGithubSpec` (won't fire for raw tarball URLs), explicit pins are preserved one-for-one, and the new diagnostic prints only fire when there were multiple candidates and the user didn't pin.

## Summary by Sourcery

Add multi-branch fallback handling for GitHub installs so repositories whose default branch is not resolvable still install correctly, while preserving explicit ref pins and existing tarball URL behavior.

Bug Fixes:
- Fix GitHub installs that previously failed with 404s when the default branch was not 'main' by trying an ordered list of candidate branches including 'main' and 'master'.

Enhancements:
- Return ordered default-branch candidates from the GitHub helper and thread them through the installer so it can iterate candidates until one succeeds, without altering explicit ref pins.
- Improve tarball cache handling for GitHub and direct tarball installs by ignoring and cleaning up zero-byte partial files and logging which branch was resolved when multiple candidates were tried.